### PR TITLE
add(rule): jsx-no-useless-style-classname

### DIFF
--- a/docs/rules/jsx-no-useless-style-classname.md
+++ b/docs/rules/jsx-no-useless-style-classname.md
@@ -1,0 +1,28 @@
+# Disallow unnecessary style and className props (react/jsx-no-useless-fragment)
+
+A style and className passed to a builtin JSX element is a no-op that can be removed.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div style={{}} />
+
+<section className="" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Foo className="" />
+<Bar style={{}} />
+```
+
+## Rule Options
+
+```js
+...
+"jsx-no-useless-style-classname": [<enabled>]
+...
+```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,7 @@
 import jsxNoUselessFragment from "./jsx-no-useless-fragment"
+import jsxNoUselessStyleClassname from "./jsx-no-useless-style-classname"
 
 export default {
   "jsx-no-useless-fragment": jsxNoUselessFragment,
+  "jsx-no-useless-style-classname": jsxNoUselessStyleClassname,
 }

--- a/src/rules/jsx-no-useless-style-classname.ts
+++ b/src/rules/jsx-no-useless-style-classname.ts
@@ -1,0 +1,97 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/experimental-utils"
+import { RuleContext } from "@typescript-eslint/experimental-utils/dist/ts-eslint/Rule"
+import * as util from "../utils"
+
+function isBuiltinElement(node: TSESTree.JSXOpeningElement): boolean {
+  return node.name.type === "JSXIdentifier" && /^[a-z]+$/.test(node.name.name)
+}
+
+function hasEmptyStyleProp(node: TSESTree.JSXOpeningElement): boolean {
+  return (
+    node.attributes.length > 0 &&
+    node.attributes.some(
+      (x) =>
+        x.type === AST_NODE_TYPES.JSXAttribute &&
+        typeof x.name.name === "string" &&
+        x.name.name === "style" &&
+        x.value?.type === AST_NODE_TYPES.JSXExpressionContainer &&
+        x.value.expression.type === AST_NODE_TYPES.ObjectExpression &&
+        x.value.expression.properties.length === 0
+    )
+  )
+}
+
+function isEmptyStringExpr(
+  node: TSESTree.JSXEmptyExpression | TSESTree.Expression
+): boolean {
+  return (
+    (node.type === AST_NODE_TYPES.Literal && node.value === "") ||
+    (node.type === AST_NODE_TYPES.TemplateLiteral &&
+      node.expressions.length === 0 &&
+      node.quasis.length === 1 &&
+      node.quasis[0].value.cooked === "")
+  )
+}
+
+function hasEmptyClassNameProp(node: TSESTree.JSXOpeningElement): boolean {
+  return (
+    node.attributes.length > 0 &&
+    node.attributes.some(
+      (x) =>
+        x.type === AST_NODE_TYPES.JSXAttribute &&
+        typeof x.name.name === "string" &&
+        x.name.name === "className" &&
+        ((x.value?.type === AST_NODE_TYPES.Literal && x.value.value === "") ||
+          (x.value?.type === AST_NODE_TYPES.JSXExpressionContainer &&
+            isEmptyStringExpr(x.value.expression)))
+    )
+  )
+}
+function checkNode(
+  node: TSESTree.JSXOpeningElement,
+  context: Readonly<RuleContext<MessageIds, []>>
+): void {
+  if (hasEmptyStyleProp(node)) {
+    context.report({
+      node,
+      messageId: "EmptyStyleProp",
+    })
+  }
+
+  if (hasEmptyClassNameProp(node)) {
+    context.report({
+      node,
+      messageId: "EmptyClassNameProp",
+    })
+  }
+}
+
+type MessageIds = "EmptyClassNameProp" | "EmptyStyleProp"
+
+export default util.createRule<[], MessageIds>({
+  name: "jsx-no-useless-style-classname",
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      description: "Disallow unnecessary style and className props.",
+      category: "Best Practices",
+      recommended: "error",
+    },
+    messages: {
+      EmptyStyleProp: "An empty style prop is a no-op.",
+      EmptyClassNameProp: "An empty className is a no-op.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXOpeningElement(node): void {
+        if (isBuiltinElement(node)) {
+          checkNode(node, context)
+        }
+      },
+    }
+  },
+})

--- a/src/tests/rules.test.ts
+++ b/src/tests/rules.test.ts
@@ -4,6 +4,11 @@ import fs from "fs"
 
 const rulesDirPath = path.join(path.dirname(__dirname), "rules")
 
+const docsDir = path.join(
+  path.join(path.dirname(path.dirname(__dirname)), "docs"),
+  "rules"
+)
+
 describe("rules snapshot", () => {
   it("matches the expected content", () => {
     const rules = fs
@@ -13,5 +18,14 @@ describe("rules snapshot", () => {
       .sort()
     const indexRules = Object.keys(rulesIndex.rules).sort()
     expect(rules).toEqual(indexRules)
+  })
+
+  it("docs count matches number of rules", () => {
+    const ruleDocs = fs
+      .readdirSync(docsDir)
+      .map((x) => path.parse(x).name)
+      .sort()
+    const indexRules = Object.keys(rulesIndex.rules).sort()
+    expect(ruleDocs).toEqual(indexRules)
   })
 })

--- a/src/tests/rules/jsx-no-useless-style-classname.test.ts
+++ b/src/tests/rules/jsx-no-useless-style-classname.test.ts
@@ -1,0 +1,67 @@
+import rule from "../../rules/jsx-no-useless-style-classname"
+import { RuleTester, getFixturesRootDir } from "../RuleTester"
+
+const rootDir = getFixturesRootDir()
+const ruleTester = new RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: rootDir,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+})
+
+ruleTester.run("jsx-no-useless-style-classname", rule, {
+  valid: [
+    {
+      code: "<Section style={{}} />",
+    },
+    {
+      code: "<Section className={''} />",
+    },
+    {
+      code: `<Section className="" />`,
+    },
+    {
+      code: "<Section className={``} />",
+    },
+    {
+      code: "<div className={`foo`} />",
+    },
+    {
+      code: "<div className={'bar'} />",
+    },
+    {
+      code: `<div className="buzz" />`,
+    },
+    {
+      code: `<div style={{height: 100}} />`,
+    },
+  ],
+  invalid: [
+    {
+      code: "<section style={{}} />",
+      errors: [{ messageId: "EmptyStyleProp" }],
+    },
+    {
+      code: "<section className={''} />",
+      errors: [{ messageId: "EmptyClassNameProp" }],
+    },
+    {
+      code: `<section className="" />`,
+      errors: [{ messageId: "EmptyClassNameProp" }],
+    },
+    {
+      code: "<section className={``} />",
+      errors: [{ messageId: "EmptyClassNameProp" }],
+    },
+    {
+      code: `<section style={{}} className="" />`,
+      errors: [
+        { messageId: "EmptyStyleProp" },
+        { messageId: "EmptyClassNameProp" },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Passing an empty string for className / style object to a builtin JSX
element is a no-op.

rel: https://github.com/sbdchd/eslint-plugin-cake/issues/5