### PR TITLE
add(rule): no-partial-arg-destructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,10 @@ s/lint
 s/test
 
 # release new version
+s/build
+
+# optional, if you want to test locally:
+yarn pack
+
 yarn publish
 ```

--- a/docs/rules/jsx-no-useless-fragment.md
+++ b/docs/rules/jsx-no-useless-fragment.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary fragments (react/jsx-no-useless-fragment)
+# Disallow unnecessary fragments (cake/jsx-no-useless-fragment)
 
 A fragment is redundant if it contains only one child that's not an expression or if it's a child of a html element, and is not a [keyed fragment](https://reactjs.org/docs/fragments.html#keyed-fragments).
 
@@ -57,6 +57,6 @@ const bar = <>foo</>
 
 ```js
 ...
-"react/jsx-no-useless-fragment": [<enabled>]
+"cake/jsx-no-useless-fragment": [<enabled>]
 ...
 ```

--- a/docs/rules/jsx-no-useless-style-classname.md
+++ b/docs/rules/jsx-no-useless-style-classname.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary style and className props (cake/jsx-no-useless-fragment)
+# Disallow unnecessary style and className props (cake/jsx-no-useless-style-classname)
 
 A style and className passed to a builtin JSX element is a no-op that can be removed.
 

--- a/docs/rules/jsx-no-useless-style-classname.md
+++ b/docs/rules/jsx-no-useless-style-classname.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary style and className props (react/jsx-no-useless-fragment)
+# Disallow unnecessary style and className props (cake/jsx-no-useless-fragment)
 
 A style and className passed to a builtin JSX element is a no-op that can be removed.
 
@@ -23,6 +23,6 @@ Examples of **correct** code for this rule:
 
 ```js
 ...
-"jsx-no-useless-style-classname": [<enabled>]
+"cake/jsx-no-useless-style-classname": [<enabled>]
 ...
 ```

--- a/docs/rules/no-partial-arg-destructure.md
+++ b/docs/rules/no-partial-arg-destructure.md
@@ -1,0 +1,36 @@
+# Disallow missing destructure params (cake/jsx-no-useless-fragment)
+
+When a component's props type has more fields than are used in the component,
+the users of the component end up needing to pass in the unused params, which is non-ideal. Also this can hide dead code.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+type Params = {
+  buzz: string
+  bar: number
+}
+function Foo({ buzz }: Params) {}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+type Params = {
+  buzz: string
+  bar: number
+}
+function Foo({ buzz, bar }: Params) {}
+function Foo({ buzz, ...rest }: Params) {}
+function Foo(props: Params) {}
+```
+
+## Rule Options
+
+```js
+...
+"cake/jsx-no-useless-style-classname": [<enabled>]
+...
+```

--- a/docs/rules/no-partial-arg-destructure.md
+++ b/docs/rules/no-partial-arg-destructure.md
@@ -1,4 +1,4 @@
-# Disallow missing destructure params (cake/jsx-no-useless-fragment)
+# Disallow missing destructure params (cake/no-partial-arg-destructure)
 
 When a component's props type has more fields than are used in the component,
 the users of the component end up needing to pass in the unused params, which is non-ideal. Also this can hide dead code.
@@ -31,6 +31,6 @@ function Foo(props: Params) {}
 
 ```js
 ...
-"cake/jsx-no-useless-style-classname": [<enabled>]
+"cake/no-partial-arg-destructure": [<enabled>]
 ...
 ```

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
   "types": "dist/index.d.ts",
   "scripts": {},
   "dependencies": {
+    "@types/lodash": "^4.14.170",
     "@typescript-eslint/experimental-utils": "^4.22.0",
     "fp-ts": "^2.10.4",
-    "io-ts": "^2.2.16"
+    "io-ts": "^2.2.16",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/s/test
+++ b/s/test
@@ -2,7 +2,7 @@
 set -ex
 
 main() {
-  ./node_modules/.bin/jest
+  ./node_modules/.bin/jest "${@}"
 }
 
 main "$@"

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,7 +1,9 @@
 import jsxNoUselessFragment from "./jsx-no-useless-fragment"
 import jsxNoUselessStyleClassname from "./jsx-no-useless-style-classname"
+import noPartialArgDestructure from "./no-partial-arg-destructure"
 
 export default {
   "jsx-no-useless-fragment": jsxNoUselessFragment,
   "jsx-no-useless-style-classname": jsxNoUselessStyleClassname,
+  "no-partial-arg-destructure": noPartialArgDestructure,
 }

--- a/src/rules/jsx-no-useless-style-classname.ts
+++ b/src/rules/jsx-no-useless-style-classname.ts
@@ -72,7 +72,6 @@ export default util.createRule<[], MessageIds>({
   name: "jsx-no-useless-style-classname",
   meta: {
     type: "suggestion",
-    fixable: "code",
     docs: {
       description: "Disallow unnecessary style and className props.",
       category: "Best Practices",

--- a/src/rules/no-partial-arg-destructure.ts
+++ b/src/rules/no-partial-arg-destructure.ts
@@ -1,0 +1,69 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/experimental-utils"
+import { RuleContext } from "@typescript-eslint/experimental-utils/dist/ts-eslint/Rule"
+import * as util from "../utils"
+
+function missingFieldsInType(
+  node: TSESTree.ObjectPattern,
+  context: Readonly<RuleContext<MessageIds, []>>
+): boolean {
+  const parserServices = util.getParserServices(context)
+  const typeChecker = parserServices.program.getTypeChecker()
+  const objectType = typeChecker.getTypeAtLocation(
+    parserServices.esTreeNodeToTSNodeMap.get(node)
+  )
+  return node.properties.length < objectType.getProperties().length
+}
+
+function checkNode(
+  node: TSESTree.FunctionDeclaration | TSESTree.ArrowFunctionExpression,
+  context: Readonly<RuleContext<MessageIds, []>>
+): void {
+  if (
+    node.params.length === 1 &&
+    node.params[0].type === AST_NODE_TYPES.ObjectPattern &&
+    node.params[0].properties.every(
+      (param) => param.type !== AST_NODE_TYPES.RestElement
+    )
+  ) {
+    if (missingFieldsInType(node.params[0], context))
+      context.report({
+        node,
+        messageId: "PartialArgDestructure",
+      })
+  }
+}
+
+type MessageIds = "PartialArgDestructure"
+
+export default util.createRule<[], MessageIds>({
+  name: "no-partial-arg-destructure",
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      description: "Usused params can hide dead code.",
+      category: "Best Practices",
+      recommended: "error",
+    },
+    messages: {
+      PartialArgDestructure:
+        "All params must be destructured, consider removing the unused fields from the param type.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      FunctionDeclaration(node): void {
+        checkNode(node, context)
+      },
+      VariableDeclaration(node): void {
+        for (const decl of node.declarations) {
+          if (decl.init?.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+            checkNode(decl.init, context)
+          }
+        }
+      },
+    }
+  },
+})

--- a/src/tests/rules/no-partial-arg-destructure.test.ts
+++ b/src/tests/rules/no-partial-arg-destructure.test.ts
@@ -79,7 +79,12 @@ function Foo({buzz, bar}: Params) {}`,
        bar: number
      }
      function Foo({buzz}: Params) {}`,
-      errors: [{ messageId: "PartialArgDestructure" }],
+      errors: [
+        {
+          messageId: "PartialArgDestructure",
+          data: { unusedFields: ["bar"] },
+        },
+      ],
     },
     {
       // shouldn't matter if we use an interface or type
@@ -89,7 +94,12 @@ function Foo({buzz, bar}: Params) {}`,
        bar: number
      }
      function Foo({buzz}: Params) {}`,
-      errors: [{ messageId: "PartialArgDestructure" }],
+      errors: [
+        {
+          messageId: "PartialArgDestructure",
+          data: { unusedFields: ["bar"] },
+        },
+      ],
     },
     {
       // should also check arrow functions
@@ -99,7 +109,12 @@ function Foo({buzz, bar}: Params) {}`,
        bar: number
      }
      const Foo = ({buzz}: Params) => {}`,
-      errors: [{ messageId: "PartialArgDestructure" }],
+      errors: [
+        {
+          messageId: "PartialArgDestructure",
+          data: { unusedFields: ["bar"] },
+        },
+      ],
     },
   ],
 })

--- a/src/tests/rules/no-partial-arg-destructure.test.ts
+++ b/src/tests/rules/no-partial-arg-destructure.test.ts
@@ -1,0 +1,97 @@
+import rule from "../../rules/no-partial-arg-destructure"
+import { RuleTester, getFixturesRootDir } from "../RuleTester"
+
+const rootDir = getFixturesRootDir()
+const ruleTester = new RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: rootDir,
+    project: "./tsconfig.json",
+  },
+})
+
+ruleTester.run("no-partial-arg-destructure", rule, {
+  valid: [
+    {
+      code: `
+type Params = {
+  buzz: string
+  bar: number
+}
+function Foo({buzz, bar}: Params) {}`,
+    },
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     function Foo({buzz, ...rest}: Params) {}`,
+    },
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     const Foo = ({buzz, ...rest}: Params) => {}`,
+    },
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     function Foo(props: Params) {}`,
+    },
+
+    {
+      code: `
+     function Foo({}: {}) {}`,
+    },
+    {
+      code: `
+     function Foo({}: any) {}`,
+    },
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     const Foo = (props: Params) => {}`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     function Foo({buzz}: Params) {}`,
+      errors: [{ messageId: "PartialArgDestructure" }],
+    },
+    {
+      // shouldn't matter if we use an interface or type
+      code: `
+     interface Params {
+       buzz: string
+       bar: number
+     }
+     function Foo({buzz}: Params) {}`,
+      errors: [{ messageId: "PartialArgDestructure" }],
+    },
+    {
+      // should also check arrow functions
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
+     const Foo = ({buzz}: Params) => {}`,
+      errors: [{ messageId: "PartialArgDestructure" }],
+    },
+  ],
+})

--- a/src/tests/rules/no-partial-arg-destructure.test.ts
+++ b/src/tests/rules/no-partial-arg-destructure.test.ts
@@ -43,6 +43,14 @@ function Foo({buzz, bar}: Params) {}`,
        buzz: string
        bar: number
      }
+     const Foo = ({buzz}: Pick<Params, "buzz">) => {}`,
+    },
+    {
+      code: `
+     type Params = {
+       buzz: string
+       bar: number
+     }
      function Foo(props: Params) {}`,
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.170":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+
 "@types/node@*", "@types/node@^14.14.41":
   version "14.14.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"


### PR DESCRIPTION
Idea here is that not destructuring all the properties of a type causes
the component to have unnecessary dependencies and hides dead code.

rel: https://github.com/sbdchd/eslint-plugin-cake/issues/7