### PR TITLE
ref(rule): make jsx-no-useless-style-classname fixable

### DIFF
--- a/docs/rules/jsx-no-useless-style-classname.md
+++ b/docs/rules/jsx-no-useless-style-classname.md
@@ -2,6 +2,8 @@
 
 A style and className passed to a builtin JSX element is a no-op that can be removed.
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:

--- a/src/tests/rules/jsx-no-useless-style-classname.test.ts
+++ b/src/tests/rules/jsx-no-useless-style-classname.test.ts
@@ -41,23 +41,28 @@ ruleTester.run("jsx-no-useless-style-classname", rule, {
   ],
   invalid: [
     {
-      code: "<section style={{}} />",
+      code: `<section foo="bar" style={{}} buzz={true} />`,
+      output: `<section foo="bar"  buzz={true} />`,
       errors: [{ messageId: "EmptyStyleProp" }],
     },
     {
-      code: "<section className={''} />",
+      code: `<section foo="bar" className={''} buzz={true} />`,
+      output: `<section foo="bar"  buzz={true} />`,
       errors: [{ messageId: "EmptyClassNameProp" }],
     },
     {
       code: `<section className="" />`,
+      output: `<section  />`,
       errors: [{ messageId: "EmptyClassNameProp" }],
     },
     {
       code: "<section className={``} />",
+      output: `<section  />`,
       errors: [{ messageId: "EmptyClassNameProp" }],
     },
     {
       code: `<section style={{}} className="" />`,
+      output: `<section   />`,
       errors: [
         { messageId: "EmptyStyleProp" },
         { messageId: "EmptyClassNameProp" },


### PR DESCRIPTION
Automatically fix violations of `jsx-no-useless-style-classname`.