### PR TITLE
ref(rule): no-partial-arg-destructure

### DIFF
--- a/src/rules/no-partial-arg-destructure.ts
+++ b/src/rules/no-partial-arg-destructure.ts
@@ -3,6 +3,13 @@ import { RuleContext } from "@typescript-eslint/experimental-utils/dist/ts-eslin
 import { difference } from "lodash"
 import * as util from "../utils"
 
+const ALLOWED_UNUSED_PROPERTIES = new Set([
+  "history",
+  "location",
+  "match",
+  "staticContext",
+])
+
 function getUnusedFields(
   node: TSESTree.ObjectPattern,
   context: Readonly<RuleContext<MessageIds, []>>
@@ -13,7 +20,10 @@ function getUnusedFields(
     parserServices.esTreeNodeToTSNodeMap.get(node)
   )
 
-  const typeProperties = objectType.getProperties().map((x) => x.name)
+  const typeProperties = objectType
+    .getProperties()
+    .map((x) => x.name)
+    .filter((x) => !ALLOWED_UNUSED_PROPERTIES.has(x))
 
   const paramProperties: string[] = []
   for (const prop of node.properties) {

--- a/src/tests/rules/no-partial-arg-destructure.test.ts
+++ b/src/tests/rules/no-partial-arg-destructure.test.ts
@@ -70,6 +70,24 @@ function Foo({buzz, bar}: Params) {}`,
      }
      const Foo = (props: Params) => {}`,
     },
+    {
+      // Basically allow the react-router `withRouter` HOC to work
+      // see: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e8adb15343a83fdd6f117bcd77783233e9210c21/types/react-router/index.d.ts#L180-L182
+      code: `
+interface RouteComponentProps {
+  history: unknown
+  location: unknown
+  match: unknown
+  staticContext?: unknown
+}
+
+interface FooProps extends RouteComponentProps {
+    title: string
+}
+
+function Foo({title}: FooProps) {}
+`,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Allow some props so react-router types work.

Using Pick with RouteComponentsProps causes `withRouter` not to work since
`withRouter` requires the component props extend `RouteComponentProps`.

Otherwise we'd need to refactor the components to not use `withRouter`.